### PR TITLE
Password length validation on registration

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -15,6 +15,13 @@ const register = async (req, res) => {
                     errorMessage: "Email already registered.Login Directly",
                 });
             }
+            //Password Length Validation
+
+            if (password.length < 8 || password.length > 20) {
+                return res.render("register", {
+                    errorMessage: "Password Length should be greater than 8 and less than 20",
+                });
+            }
 
             // Hash the password
 
@@ -115,4 +122,4 @@ const logout = async (req, res) => {
     res.redirect("/");
 }
 
-export { register,login, logout };
+export { register, login, logout };


### PR DESCRIPTION
During user registration, the password field should enforce a length requirement of 8-20 characters. However, users were able to register with passwords shorter than 8 characters, which violated the specified constraints. 
Fixes #242 


<img width="568" alt="Screenshot 2024-05-22 at 12 32 14 AM" src="https://github.com/Note-Vault/Note-Vault/assets/129958210/4f943299-2d56-44f7-bc24-1532c3f245c5">
