### PR TITLE
Search Bar Executes Without taking Input on Notes Search #270

### DIFF
--- a/views/note.ejs
+++ b/views/note.ejs
@@ -188,7 +188,7 @@
         <a href="/" class="text-2xl font-bold text-white no-underline">NoteVault</a>
         <div class="flex items-center flex-wrap space-x-4">
           <form action="/note/search" class="flex">
-            <input type="search" id="tag" name="tag" class="form-input rounded-l px-4 py-2" placeholder="Search">
+            <input type="search" id="tag" name="tag" class="form-input rounded-l px-4 py-2" placeholder="Search" required>
             <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded-r">
               <i class="fas fa-search"></i>
             </button>

--- a/views/search.ejs
+++ b/views/search.ejs
@@ -38,6 +38,7 @@
               name="tag"
               class="form-control"
               placeholder="Search"
+              required
             />
           </div>
           <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
### Description:

The search bar in the navbar, intended for searching notes made by the user on the website, it automatically executes the search when the search button is clicked, even if no input is provided. This leads to an unnecessary and empty search result being displayed.

So, I solved this problem by adding required attribute in the input tag of files `note.ejs` and `seach.ejs` .


### Screenshots:

**with issue -**
![333674344-fbb42036-8dc0-442b-86c1-faa7d92c0abf](https://github.com/Note-Vault/Note-Vault/assets/115466381/ec00fbbe-4b8f-44d8-975c-d585fecb6984)


**after solving issue -**
**1]**
![image](https://github.com/Note-Vault/Note-Vault/assets/115466381/dca885f0-8490-49b4-b0ad-985bca1c8d95)

**2]**
![image](https://github.com/Note-Vault/Note-Vault/assets/115466381/276c5d03-80ec-4678-9219-7ff5af8929a6)


